### PR TITLE
Fixed bug where handler tries to unregister itself

### DIFF
--- a/emmett.js
+++ b/emmett.js
@@ -333,6 +333,7 @@
         n,
         j,
         m,
+        z,
         a,
         event,
         child,
@@ -366,11 +367,19 @@
             'scope' in handlers[j] ? handlers[j].scope : this,
             event
           );
-          if (!handlers[j].once)
+
+          // Since the listener callback can mutate the _handlers,
+          // we register the handlers we want to remove, not the ones
+          // we want to keep
+          if (handlers[j].once)
             a.push(handlers[j]);
         }
 
-        this._handlers[eventName] = a;
+        // Go through handlers to remove
+        for (z = 0; z < a.length; z++) {
+          this._handlers[eventName].splice(a.indexOf(a[z]), 1);
+        }
+
       }
     }
 

--- a/test/emmett.test.js
+++ b/test/emmett.test.js
@@ -9,6 +9,18 @@ describe('Emitter', function() {
           count += e.data.count || 1;
         };
 
+    it('unregistering event in event callback should work', function() {
+      var callback = function () {
+        e.off('myEvent', callback);
+        count++;
+      };
+      e.on('myEvent', callback);
+      e.emit('myEvent');
+      e.emit('myEvent');
+      assert.equal(count, 1);
+      count = 0;
+    });
+
     it('dispatching an event with no trigger does nothing', function() {
       e.emit('myEvent');
       assert.equal(count, 0);


### PR DESCRIPTION
I found this bug using Baobab (https://github.com/Yomguithereal/baobab). You can get into situations where a "handler" wants to unregister itself, but this causes problems with current implementation. The reason is that a new array is created and mutations done during handler callbacks will not be registered. So this fix solves that.