### PR TITLE
Fixed issue with emitting and handler unregisters events

### DIFF
--- a/emmett.js
+++ b/emmett.js
@@ -333,6 +333,7 @@
         n,
         j,
         m,
+        z,
         a,
         event,
         child,
@@ -366,11 +367,19 @@
             'scope' in handlers[j] ? handlers[j].scope : this,
             event
           );
-          if (!handlers[j].once)
+
+          // Since the listener callback can mutate the _handlers,
+          // we register the handlers we want to remove, not the ones
+          // we want to keep
+          if (handlers[j].once)
             a.push(handlers[j]);
         }
 
-        this._handlers[eventName] = a;
+        // Go through handlers to remove
+        for (z = 0; z < a.length; z++) {
+          this._handlers[eventName].splice(a.indexOf(a[z]), 1);
+        }
+
       }
     }
 

--- a/emmett.js
+++ b/emmett.js
@@ -363,16 +363,24 @@
         a = [];
 
         for (j = 0, m = handlers.length; j !== m; j += 1) {
-          handlers[j].handler.call(
-            'scope' in handlers[j] ? handlers[j].scope : this,
-            event
-          );
 
-          // Since the listener callback can mutate the _handlers,
-          // we register the handlers we want to remove, not the ones
-          // we want to keep
-          if (handlers[j].once)
-            a.push(handlers[j]);
+          // We have to verify that the handler still exists in the array,
+          // as it might have been mutated already
+          if ((this._handlers[eventName] && this._handlers[eventName].indexOf(handlers[j]) >= 0) || 
+                this._handlersAll.indexOf(handlers[j]) >= 0) {
+
+            handlers[j].handler.call(
+              'scope' in handlers[j] ? handlers[j].scope : this,
+              event
+            );
+
+            // Since the listener callback can mutate the _handlers,
+            // we register the handlers we want to remove, not the ones
+            // we want to keep
+            if (handlers[j].once)
+              a.push(handlers[j]);
+
+          }
         }
 
         // Go through handlers to remove

--- a/test/emmett.test.js
+++ b/test/emmett.test.js
@@ -9,7 +9,7 @@ describe('Emitter', function() {
           count += e.data.count || 1;
         };
 
-    it('unregistering event in event callback should work', function() {
+    it('unregistering event in emit callback should work', function() {
       var callback = function () {
         e.off('myEvent', callback);
         count++;
@@ -17,6 +17,19 @@ describe('Emitter', function() {
       e.on('myEvent', callback);
       e.emit('myEvent');
       e.emit('myEvent');
+      assert.equal(count, 1);
+      count = 0;
+    });
+
+    it('unregistering other event in emit callback should work', function() {
+      var callback = function () {
+        e.off('myEvent2', callback);
+        count++;
+      };
+      e.once('myEvent', callback);
+      e.on('myEvent2', callback);
+      e.emit('myEvent');
+      e.emit('myEvent2');
       assert.equal(count, 1);
       count = 0;
     });

--- a/test/emmett.test.js
+++ b/test/emmett.test.js
@@ -9,6 +9,18 @@ describe('Emitter', function() {
           count += e.data.count || 1;
         };
 
+    it('unregistering event in event callback should work', function() {
+      var callback = function () {
+        e.off('myEvent', callback);
+        count++;
+      };
+      e.on('myEvent', callback);
+      e.emit('myEvent');
+      e.emit('myEvent');
+      assert.equal(count, 1);
+      count = 0;
+    });
+
     it('dispatching an event with no trigger does nothing', function() {
       e.emit('myEvent');
       assert.equal(count, 0);


### PR DESCRIPTION
I met this issue using Baobab and the problem is related to Emmett. When an event is emitted you might be unregistering events in the handler. Emmett did not take care of this as it made its own array of handlers to trigger. If one trigger would be unregistered during one of the emits, it would still trigger the unregistered handler, causing, in this case, Baobab to give an error.

Specifically with Baobab this happens using React JS and the tree mixin. Where components are mounted and unmounted, causing a scenario that provokes this.