### PR TITLE
Added a test case that exposes an unexpected behaviour of once with off

### DIFF
--- a/test/emmett.test.js
+++ b/test/emmett.test.js
@@ -167,6 +167,27 @@ describe('Emitter', function() {
 
       assert.strictEqual(count, 2);
     });
+
+
+    it('make sure once only emits once after removeing callback', function() {
+      var count = 0,
+          ne = new emitter(),
+          callback1 = function () { count++; },
+          callback2 = function () { count++; };
+
+      ne.once('myEvent', callback1);
+      ne.once('myEvent', callback2);
+
+      ne.off('myEvent', callback1);
+
+      ne.emit('myEvent');
+      ne.emit('myEvent');
+
+      assert.equal(count, 1);
+      count = 0;
+    });
+
+
   });
 
   describe('api', function() {


### PR DESCRIPTION
This test shows that when you register two callbacks to the same event, then remove one (with ".off"), the other one will fire all the time even if you have specified "once" so it should only fire once. 

We could really use a fix :)