### PR TITLE
Fix ASCII Character Bug

### DIFF
--- a/emmett.js
+++ b/emmett.js
@@ -189,7 +189,7 @@
       };
 
       // Defining the list in which the handler should be inserted
-      if (typeof event === 'string' || typeof event === 'symbol') {
+      if (typeof event === 'string' || typeof event === 'symbol') {
         if (!this._handlers[event])
           this._handlers[event] = [];
         handlersList = this._handlers[event];
@@ -324,7 +324,7 @@
 
     // Variant 5
     else if (arguments.length === 1 &&
-             (typeof events === 'string' || typeof events === 'symbol')) {
+             (typeof events === 'string' || typeof events === 'symbol')) {
       delete this._handlers[events];
     }
 


### PR DESCRIPTION
After the `||` operators added in cf32d8cc688f9519f316e525341f41d993b55da6, there are hex characters C2 and A0 (latin capital letter A with circumflex and non-breaking space).

This is breaking emmett when used with webpack. Output:

```
if (typeof event === 'string' ||Â typeof event === 'symbol') {
...
(typeof events === 'string' ||Â typeof events === 'symbol')) {
```