### PR TITLE
Handle cases where the once was already remove by a handler function …

### DIFF
--- a/emmett.js
+++ b/emmett.js
@@ -479,7 +479,9 @@
             this._handlersAll;
 
         const index = parent.indexOf(onces[j]);
-        index !== -1 && parent.splice(index, 1);
+        if (index !== -1) {
+          parent.splice(index, 1);
+        }
       }
     }
 

--- a/emmett.js
+++ b/emmett.js
@@ -478,7 +478,8 @@
             this._handlersComplex :
             this._handlersAll;
 
-        parent.splice(parent.indexOf(onces[j]), 1);
+        const index = parent.indexOf(onces[j]);
+        index !== -1 && parent.splice(index, 1);
       }
     }
 

--- a/emmett.js
+++ b/emmett.js
@@ -478,9 +478,9 @@
             this._handlersComplex :
             this._handlersAll;
 
-        const index = parent.indexOf(onces[j]);
-        if (index !== -1) {
-          parent.splice(index, 1);
+        const onceIndex = parent.indexOf(onces[j]);
+        if (onceIndex !== -1) {
+          parent.splice(onceIndex, 1);
         }
       }
     }


### PR DESCRIPTION
…invocation.

In this case the splice would remove the index -1 and corrupt the handlers list.  This would result in baobab cursors that would never be notified of updates until the baobab tree was rebuilt.